### PR TITLE
Corrige domínio dos links de alerta do INMET

### DIFF
--- a/custom_components/inmet/geo_location.py
+++ b/custom_components/inmet/geo_location.py
@@ -171,7 +171,7 @@ class InmetEvent(GeolocationEvent):
         self._alert_start_date = datetime.strptime(alert["inicio"], DATE_FORMAT)
         self._alert_end_date = datetime.strptime(alert["fim"], DATE_FORMAT)
         self._alert_sequence = alert["id_sequencia"]
-        self._alert_url = f"https://alertas2.inmet.gov.br/{self._alert_id}"
+        self._alert_url = f"https://avisos.inmet.gov.br/{self._alert_id}"
 
         self._attr_name = f"{self._alert_id} {self._description} {self._alert_severity}"
 


### PR DESCRIPTION
## Summary
- Os links das entidades `geo_location` apontavam para `alertas2.inmet.gov.br`, um domínio que não corresponde aos avisos oficiais do INMET.
- Corrigido para `avisos.inmet.gov.br`, que é o domínio efetivamente usado pelo site do INMET para os alertas.

## Test plan
- [x] Confirmado que não há outras ocorrências de `alertas2.inmet.gov.br` no repositório.

Fixes #10

---
_Generated by [Claude Code](https://claude.ai/code/session_01WB7JY96Da7Zq6E3yxdjJmj)_